### PR TITLE
Changed max matches param

### DIFF
--- a/app/src/repositories/ParagraphDataProvider.php
+++ b/app/src/repositories/ParagraphDataProvider.php
@@ -91,9 +91,13 @@ class ParagraphDataProvider extends BaseDataProvider
     protected function prepareTotalCount()
     {
         $count = $this->query->get()->getTotal();
-        if ($count > 1000) {
-            $this->query->maxMatches($count);
+        /**
+         * https://manual.manticoresearch.com/Searching/Options#max_matches
+         */
+        if ($count > 10000) {
+            $count = 10000;
         }
+        $this->query->maxMatches($count);
         return $count;
     }
 }


### PR DESCRIPTION
Изменен параметр max matches, установлен максимум в 10 000, кол-во результатов в выдаче поиска, должно сильно повлиять на производительность:
https://manual.manticoresearch.com/Searching/Options#max_matches

Яндекс перевод:
> Введенный для контроля и ограничения использования оперативной памяти параметр max_matches определяет, сколько совпадений будет храниться в оперативной памяти при поиске в каждой таблице. Каждое найденное совпадение по-прежнему будет обработано; но только лучшие N из них будут сохранены в памяти и в конце концов возвращены клиенту. Предположим, что таблица содержит 2 000 000 совпадений для запроса. Вам редко (если вообще когда-либо) нужно извлекать их все. Скорее всего, вам нужно отсканировать их все, но выбрать только “лучшие” не более, скажем, 500 по некоторым критериям (т.е. отсортированный по релевантности, цене или чему-либо еще), и отобразите эти 500 совпадений конечному пользователю на страницах от 20 до 100 совпадений. И отслеживание только 500 лучших совпадений намного эффективнее с точки зрения оперативной памяти и процессора, чем сохранение всех 2 000 000 совпадений, их сортировка, а затем отбрасывание всего, кроме первых 20, необходимых для отображения страницы результатов поиска. max_matches контролирует N в этом "лучшем N" количестве.