### PR TITLE
Параметр поискового запроса max_matches выведен в конфигурацию

### DIFF
--- a/app/config/params.php
+++ b/app/config/params.php
@@ -11,7 +11,8 @@ return [
     'urlShortenerUrl' => getenv('URL_SHORTENER_URL'), // Хост в сети интернет, в локальной сети docker - это наименования сервиса
     'manticore' => [
         'host' => 'manticore',
-        'port' => 9308
+        'port' => 9308,
+        'max_matches' => getenv('MANTICORE_MAX_MATCHES') ?? 0, // Maximum amount of matches that the server keeps in RAM for each table and can return to the client. Default is unlimited.
     ],
     'searchResults' => [
         'pageSize' => (int)getenv('PAGE_SIZE'),

--- a/app/src/repositories/ParagraphDataProvider.php
+++ b/app/src/repositories/ParagraphDataProvider.php
@@ -90,12 +90,15 @@ class ParagraphDataProvider extends BaseDataProvider
 
     protected function prepareTotalCount()
     {
+        $max_matches = (int)\Yii::$app->params['manticore']['max_matches'];
         $count = $this->query->get()->getTotal();
         /**
          * https://manual.manticoresearch.com/Searching/Options#max_matches
+         * Если ограничение max_matches установлено, то устанавливаем счетчик кол-во совпадений равный параметру max_matches
+         * Иначе устанавливаем значение запроса max_matches равное кол-во существующих результатов, т.е. выдача без ограничения
          */
-        if ($count > 10000) {
-            $count = 10000;
+        if ($max_matches !== 0) {
+            $count = $max_matches;
         }
         $this->query->maxMatches($count);
         return $count;

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -21,6 +21,7 @@ services:
       COOKIE_DOMAIN: svodd.ru
       COOKIE_VALIDATION_KEY_FILE: /run/secrets/app_cookie_validation_key
       MANTICORE_DB_NAME_COMMON: common_library
+      MANTICORE_MAX_MATCHES: 10000
     secrets:
       - app_db_password
       - app_cookie_validation_key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       COOKIE_DOMAIN: localhost
       COOKIE_VALIDATION_KEY_FILE: /run/secrets/app_cookie_validation_key
       MANTICORE_DB_NAME_COMMON: common_library
+      MANTICORE_MAX_MATCHES: 0
     secrets:
       - app_db_password
       - app_cookie_validation_key

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,8 @@ ext2/ext3/ext4:
 resize2fs /dev/vdb1
 
 -----------------------------
+
+`/etc/fstab`
 ```
 LABEL=cloudimg-rootfs / ext4 defaults 0 1
 /swap-2048M none swap sw 0 0


### PR DESCRIPTION
ограничивающий выдачу параметр max_matches выведен в файл конфигурации сервиса, в режиме dev разработки на localhost значение по умолчанию установлено в 0, что означfет без ограничения. Для конфигурации рабочего режима сервера, значение установлено 10 000, при необходимости, теперь значение легко меняется в файле конфигурации.